### PR TITLE
Updated NetworkClientTests to cover Post request function

### DIFF
--- a/AllSee/Core/Data/Remote/Client/NetworkClient.swift
+++ b/AllSee/Core/Data/Remote/Client/NetworkClient.swift
@@ -48,7 +48,7 @@ final class NetworkClient {
                 throw NetworkError.unknownError(urlError)
             }
         } catch let error as NetworkError {
-            log.error("[NetworkClient] Network Error: \(error)")
+            log.error("[NetworkClient] Uncaught Network Error: \(error)")
             throw error
         } catch {
             log.error("[NetworkClient] Unknown Error: \(error)")

--- a/AllSeeTests/Core/Data/Remote/Client/NetworkClientTests.swift
+++ b/AllSeeTests/Core/Data/Remote/Client/NetworkClientTests.swift
@@ -13,6 +13,8 @@ final class NetworkClientTests: XCTestCase {
     var sut: NetworkClient!
     var log: Logger!
     
+    private let mockBaseURL = "https://api.mock.com"
+    
     override func setUp() {
         super.setUp()
         
@@ -31,7 +33,13 @@ final class NetworkClientTests: XCTestCase {
         super.tearDown()
     }
     
-    func testGetSuccess() async throws {
+/*
+ * ================================================================================
+ * Get method
+ * ================================================================================
+ */
+    
+    func test_GetSuccess() async throws {
         let expectedData = "Hello, world!".data(using: .utf8)!
         
         MockURLProtocol.handler = { request in
@@ -39,13 +47,13 @@ final class NetworkClientTests: XCTestCase {
             return (response, expectedData)
         }
         
-        let url = URL(string: "https://mockapi.com")!
+        let url = URL(string: mockBaseURL)!
         let data = try await sut.get(from: url)
         
         XCTAssertEqual(data, expectedData)
     }
     
-    func testGetBadStatusCode() async throws {
+    func test_GetBadStatusCode() async throws {
         let responseData = Data()
         
         MockURLProtocol.handler = { request in
@@ -53,7 +61,7 @@ final class NetworkClientTests: XCTestCase {
             return (response, responseData)
         }
         
-        let url = URL(string: "https://mockapi.com")!
+        let url = URL(string: mockBaseURL)!
         
         do {
             _ = try await sut.get(from: url)
@@ -68,12 +76,12 @@ final class NetworkClientTests: XCTestCase {
         }
     }
     
-    func testGetTimedOut() async {
+    func test_GetTimedOut() async {
         MockURLProtocol.handler = { _ in
             throw URLError(.timedOut)
         }
         
-        let url = URL(string: "https://mockapi.com")!
+        let url = URL(string: mockBaseURL)!
         
         do {
             _ = try await sut.get(from: url)
@@ -87,6 +95,221 @@ final class NetworkClientTests: XCTestCase {
             }
         } catch {
             XCTFail("Expected NetworkError.requestTimedOut, got \(error)")
+        }
+    }
+    
+    func test_GetNotConnectedToInternet() async {
+        MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        
+        let url = URL(string: mockBaseURL)!
+        
+        do {
+            _ = try await sut.get(from: url)
+            XCTFail("Expected NetworkError.notConnectedToInternet")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.notConnectedToTheInternet:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.notConnectedToInternet")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.notConnectedToInternet")
+        }
+    }
+    
+    func test_GetBadURL() async {
+        MockURLProtocol.handler = { _ in throw URLError(.badURL) }
+        
+        let url = URL(string: mockBaseURL)!
+        
+        do {
+            _ = try await sut.get(from: url)
+            XCTFail("Expected NetworkError.invalidUrl")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.invalidUrl:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.invalidUrl")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.invalidUrl")
+        }
+    }
+    
+    func test_GetUnknownNetworkError() async {
+        MockURLProtocol.handler = { _ in throw URLError(.unknown) }
+        
+        let url = URL(string: mockBaseURL)!
+        
+        do {
+            _ = try await sut.get(from: url)
+            XCTFail("Expected NetworkError.unknownError")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.unknownError:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.unknownError")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.unknownError")
+        }
+    }
+
+/*
+ * ================================================================================
+ * Get method
+ * ================================================================================
+ */
+    
+    func test_PostSuccess() async throws {
+        let expectedData = "Success".data(using: .utf8)!
+        
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, expectedData)
+        }
+        
+        let url = URL(string: mockBaseURL)!
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        let data = try await sut.post(to: url, headers: ["Content-Type": "application/json"], components: components)
+        
+        XCTAssertEqual(data, expectedData)
+    }
+    
+    func test_PostTimedOut() async throws {
+        MockURLProtocol.handler = { _ in
+            throw URLError(.timedOut)
+        }
+        
+        let url = URL(string: mockBaseURL)!
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        do {
+            _ = try await sut.post(to: url, components: components)
+            XCTFail("Expected NetworkError.requestTimedOut")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.requestTimedOut:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.requestTimedOut, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.requestTimedOut, got \(error)")
+        }
+    }
+    
+    func test_PostNotConnectedToInternet() async {
+        MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        
+        let url = URL(string: mockBaseURL)!
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        do {
+            _ = try await sut.post(
+                to: url,
+                components: components
+            )
+            XCTFail("Expected NetworkError.notConnectedToInternet")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.notConnectedToTheInternet:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.notConnectedToInternet, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.notConnectedToInternet, got \(error)")
+        }
+    }
+    
+    func test_PostBadURL() async {
+        MockURLProtocol.handler = { _ in throw URLError(.badURL) }
+        
+        let url = URL(string: mockBaseURL)!
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        do {
+            _ = try await sut.post(
+                to: url,
+                components: components
+            )
+            XCTFail("Expected NetworkError.invalidUrl")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.invalidUrl:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.invalidUrl, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.invalidUrl, got \(error)")
+        }
+    }
+    
+    func test_PostUnknownError() async {
+        MockURLProtocol.handler = { _ in throw URLError(.unknown) }
+        
+        let url = URL(string: mockBaseURL)!
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        do {
+            _ = try await sut.post(
+                to: url,
+                components: components
+            )
+            XCTFail("Expected NetworkError.unknownError")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.unknownError:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.unknownError, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.unknownError, got \(error)")
+        }
+    }
+    
+    func test_PostBadServerResponse() async {
+        let responseData = Data()
+        
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+            return (response, responseData)
+        }
+        
+        let url = URL(string: mockBaseURL)!
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        do {
+            _ = try await sut.post(
+                to: url,
+                components: components
+            )
+            XCTFail("Expected NetworkError.badServerResponse")
+        } catch let error as NetworkError {
+            switch error {
+            case NetworkError.badServerResponse:
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Expected NetworkError.badServerResponse, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected NetworkError.badServerResponse, got \(error)")
         }
     }
 }


### PR DESCRIPTION
### Description

This PR updates NetworkClientTests to include the post request function.

Test coverage is now 89% of file.