### PR TITLE
Implement SaveAccessTokens in RegistrationRepository

### DIFF
--- a/AllSee/Features/Registration/Data/Repository/RegistrationRepositoryImpl.swift
+++ b/AllSee/Features/Registration/Data/Repository/RegistrationRepositoryImpl.swift
@@ -35,9 +35,10 @@ final class RegistrationRepositoryImpl: RegistrationRepository {
         }
     }
     
-    /*
+    
     func saveAccessAndRefreshTokens(accessToken: String, refreshToken: String) throws {
-        <#code#>
+        try upsertKeyChainTokenUseCase.execute(accessToken, identifier: KeyChainTokens.accessTokenIdentifier, service: KeyChainTokens.service)
+        try upsertKeyChainTokenUseCase.execute(accessToken, identifier: KeyChainTokens.refreshTokenIdentifier, service: KeyChainTokens.service)
     }
-    */
+    
 }

--- a/AllSee/Features/Registration/Domain/Repository/RegistrationRepository.swift
+++ b/AllSee/Features/Registration/Domain/Repository/RegistrationRepository.swift
@@ -11,5 +11,5 @@ protocol RegistrationRepository {
     
     func fetchIndividualInformation(completion: @escaping (Result<Individual, Error>) -> Void) async throws
     
-    //func saveAccessAndRefreshTokens(accessToken: String, refreshToken: String) throws
+    func saveAccessAndRefreshTokens(accessToken: String, refreshToken: String) throws
 }


### PR DESCRIPTION
### Description

This PR implements a delegation function to save the access and refresh tokens into the key chain. As this is a delegation, it's not tested. 